### PR TITLE
Fix ex_doc

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule ZigParser.MixProject do
   defp deps do
     [
       {:pegasus, "~> 0.2.2", runtime: false},
-      {:ex_doc, ">= 0.0.0", runtime: false}
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end
 end


### PR DESCRIPTION
Congrats on the release! This lib and approach to parse Zig source is so cool!.

If ex_doc is not dev-only, it will cause conflict with a lot downstream libs which usually set ex_doc to dev-only
```
Dependencies have diverged:
* ex_doc (Hex package)
  the :only option for dependency ex_doc

  > In mix.exs:
    {:ex_doc, ">= 0.0.0", [env: :prod, repo: "hexpm", hex: "ex_doc", only: :dev, runtime: false]}

  does not match the :only option calculated for

  > In deps/zig_parser/mix.exs:
    {:ex_doc, ">= 0.0.0", [env: :prod, hex: "ex_doc", repo: "hexpm", optional: false]}

  Remove the :only restriction from your dep
** (Mix) Can't continue due to errors on dependencies
```